### PR TITLE
Don't forget the current working directory

### DIFF
--- a/windows/install.cmd
+++ b/windows/install.cmd
@@ -1,6 +1,9 @@
 @ECHO OFF
 SETLOCAL
 
+@setlocal enableextensions
+@cd /d "%~dp0"
+
 SET MS_EMOJI_FONT_PATH="%SystemRoot%\Fonts\seguiemj.ttf"
 SET MS_FONT_PATH="%SystemRoot%\Fonts\seguisym.ttf"
 SET EMOJI_FONT_PATH="%CD%\EmojiOneColor-SVGinOT.ttf"


### PR DESCRIPTION
When you right click and run the `install.cmd` script as an administrator, the script forgets the working directory and instead uses `%systemroot%/system32` as the working directory, this throws an error later on during installation because we are looking for the file `EmojiOneColor-SVGinOT` in `%systemroot%/system32`. 

The two line additions fix this problem. Now you can right click on the script and install the fonts from anywhere.

You can reproduce this bug by running the script as an administrator from the extracted path (right click -> Run as administrator). Fix: download this fork, run it as an admin and it should work fine.

<!--
Thank you for making a pull request!

This project has a clean and consistent git history. Commit messages
must be in the following format to be merged:

tag: Title without period less than 50 characters

Comment body text, if needed, describing what and why wrapped to 72
characters.
-->
