### PR TITLE
Script now detects if running under Ubuntu or openSUSE

### DIFF
--- a/linux/install.sh
+++ b/linux/install.sh
@@ -10,12 +10,11 @@ if [ $RETURN -ne 0 ];then
 	# Detects if using Ubuntu or openSUSE, then install.
 	if [[ "$(. /etc/os-release; echo $NAME)" =~ "Ubuntu" ]]; then
 		sudo apt-get install ttf-bitstream-vera
-		exit 1
 	fi
 	if [[ "$(. /etc/os-release; echo $NAME)" =~ "openSUSE" ]]; then
 		sudo zypper install bitstream-vera-fonts
-		exit 1
 	fi
+	exit 1
 fi
 echo "NOTE: Changing default font family to Bitstream Vera"
 

--- a/linux/install.sh
+++ b/linux/install.sh
@@ -7,8 +7,15 @@ fc-list | grep "Bitstream Vera" > /dev/null
 RETURN=$?
 if [ $RETURN -ne 0 ];then
   echo "Bitstream Vera font family not found. Please install it:"
-  echo "sudo apt-get install ttf-bitstream-vera"
-  exit 1
+	# Detects if using Ubuntu or openSUSE, then install.
+	if [[ "$(. /etc/os-release; echo $NAME)" =~ "Ubuntu" ]]; then
+		sudo apt-get install ttf-bitstream-vera
+		exit 1
+	fi
+	if [[ "$(. /etc/os-release; echo $NAME)" =~ "openSUSE" ]]; then
+		sudo zypper install bitstream-vera-fonts
+		exit 1
+	fi
 fi
 echo "NOTE: Changing default font family to Bitstream Vera"
 


### PR DESCRIPTION
Previously the script after detecting whatever the font is installed or not, proceed to the installation using "apt-get install", but if the user run the script under eg: openSUSE, this will not work, so i edited the linux/install.sh to detect if using Ubuntu or openSUSE, from there is easy to add support for other OS.